### PR TITLE
Fixing injection keywords syntax highlighting in comments

### DIFF
--- a/syntaxes/mysql-injection.json
+++ b/syntaxes/mysql-injection.json
@@ -23,5 +23,5 @@
 		}
 	},
 	"scopeName": "source.mysql-injection.sql",
-	"injectionSelector": "L:source.sql"
+	"injectionSelector": "L:source.sql -comment"
 }


### PR DESCRIPTION
With this fix, injection grammar will not take priority over comments syntax highlighting