### PR TITLE
Added isIdentity field for Port

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
             "displayName": "%mysql.connectionOptions.port.displayName%",
             "description": "%mysql.connectionOptions.port.description%",
             "valueType": "number",
-			"isIdentity": true,
+            "isIdentity": true,
             "groupName": "%mysql.connectionOptions.groupName.server%",
             "defaultValue": 3306
           },

--- a/package.json
+++ b/package.json
@@ -242,6 +242,7 @@
             "displayName": "%mysql.connectionOptions.port.displayName%",
             "description": "%mysql.connectionOptions.port.description%",
             "valueType": "number",
+			"isIdentity": true,
             "groupName": "%mysql.connectionOptions.groupName.server%",
             "defaultValue": 3306
           },


### PR DESCRIPTION
After this fix, owner_uri to mysqltoolsservice will include port which will make connections with same username, localhost but different port unique.


Related PR: Added port property in unique intellisense uri created
https://github.com/microsoft/mysqltoolsservice/pull/4

Fix for issue: https://github.com/microsoft/azuredatastudio-mysql/issues/101